### PR TITLE
More renames to Erbium

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ and contributors (see source file comments, the upstream project, and the versio
 Table of Contents
 ------------------
 
-1. [Further Documentation](#further-documentation)
-2. [Default Controls](#default-controls)
-3. [Paths](#paths)
-4. [Configuration File](#configuration-file)
-5. [Command-line Options](#command-line-options)
-6. [Compiling](#compiling)
-7. [Docker](#docker)
-8. [Version Scheme](#version-scheme)
+1. [Default Controls](#default-controls)
+2. [Paths](#paths)
+3. [Configuration File](#configuration-file)
+4. [Command-line Options](#command-line-options)
+5. [Compiling](#compiling)
+6. [Docker](#docker)
+7. [Version Scheme](#version-scheme)
 
 Default controls
 ----------------


### PR DESCRIPTION
Replaces references to Luanti with Erbium. Also removes a line that is no longer relevant.