### PR TITLE
Remove whitespaces caused by the implementation of dark mode

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -311,7 +311,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 
 	driver->setFog(getMenuSkyColor());
 	driver->beginScene(true, true, getMenuSkyColor());
-	
+
 	if (g_settings->getBool("menu_clouds")) {
 		g_menuclouds->step(dtime * 3);
 		g_menucloudsmgr->drawAll();

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -134,7 +134,7 @@ public:
 	{
 		return m_device->run();
 	}
-	
+
 	void setMenuSkyColor(video::SColor &color);
 	void setMenuCloudsColor(video::SColor &color);
 	const video::SColor getMenuSkyColor();

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -347,10 +347,10 @@ void GUIEngine::run()
 				m_script->handleMainMenuEvent("WindowInfoChange");
 				last_window_info = window_info;
 			}
-			
+
 			driver->beginScene(true, true, m_rendering_engine->getMenuSkyColor());
 			driver->setFog(m_rendering_engine->getMenuSkyColor());
-			
+
 			if (m_clouds_enabled) {
 				drawClouds(dtime);
 				drawOverlay(driver);


### PR DESCRIPTION
I'm pretty sure these are the only whitespaces that git throws a fit about.

I checked the entire repo using 'grep -rIn "[[:blank:]]$" .' but you can see them here: [https://github.com/IonicCheese/erbium/actions/runs/20018415712/job/57400386981](https://github.com/IonicCheese/erbium/actions/runs/20018415712/job/57400386981)